### PR TITLE
Minor Rubocop style fixes, and enforce higher Rubocop version

### DIFF
--- a/devise_rails_api_authentication.gemspec
+++ b/devise_rails_api_authentication.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rubocop', '~> 0.28.0'
+  spec.add_development_dependency 'rubocop', '~> 0.49'
   spec.add_development_dependency 'guard-rubocop'
   spec.add_development_dependency 'guard-rspec'
 end

--- a/lib/devise_rails_api_authentication/authenticatable.rb
+++ b/lib/devise_rails_api_authentication/authenticatable.rb
@@ -18,7 +18,7 @@ module DeviseRailsApiAuthentication
     def generate_authentication_token
       loop do
         token = Devise.friendly_token
-        break token if self.class.where(authentication_token: token).count == 0
+        break token if self.class.where(authentication_token: token).count.zero?
       end
     end
   end

--- a/lib/devise_rails_api_authentication/context.rb
+++ b/lib/devise_rails_api_authentication/context.rb
@@ -34,7 +34,7 @@ module DeviseRailsApiAuthentication
     end
 
     def user
-      fail NotImplementedError
+      raise NotImplementedError
     end
   end
 end

--- a/lib/devise_rails_api_authentication/version.rb
+++ b/lib/devise_rails_api_authentication/version.rb
@@ -1,3 +1,3 @@
 module DeviseRailsApiAuthentication
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'.freeze
 end


### PR DESCRIPTION
There's a security vulnerability which is cleared away by upgrading the
Rubocop version used.

https://nvd.nist.gov/vuln/detail/CVE-2017-8418